### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,8 @@
 name: Maven Build Monorepo
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/appi147/ExpenseTracker/security/code-scanning/1](https://github.com/appi147/ExpenseTracker/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the least privileges required for the workflow to function correctly. Since the workflow primarily involves reading repository contents and does not perform any write operations, the permissions can be set to `contents: read`. This change ensures that the `GITHUB_TOKEN` has minimal access, reducing the risk of unintended modifications or security vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
