### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: SonarQube Monorepo Unified Scan
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/appi147/ExpenseTracker/security/code-scanning/7](https://github.com/appi147/ExpenseTracker/security/code-scanning/7)

To fix the problem, we need to add an explicit `permissions` block to limit the GITHUB_TOKEN's permissions. The best practice is to set this key at the top level of the workflow YAML, so it applies to all jobs (unless a job-specific override is needed). In this case, adding the following at the top level (after `name:` and before or after `on:`) is sufficient:

```yaml
permissions:
  contents: read
```

This grants all jobs in the workflow read-only access to repository contents, which is the minimal privilege required for the actions being performed. No steps in the shown workflow require write access. No other code or configuration changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
